### PR TITLE
feat: extended history management functionality for multi-selected objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "main": "dist/index.js",
   "files": [
     "dist",
-    "src",
-    "tests"
+    "src"
   ],
   "types": "dist/index.d.ts",
   "keywords": [

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -102,21 +102,16 @@ export class CanvasWithHistory extends Canvas {
    */
   private _handleSelectionUpdated(options: { selected: FabricObject[] }) {
     const allSelectedObjects = this.getActiveObjects();
-
-    if (allSelectedObjects.length > 1) {
-      this._selectedObjects = allSelectedObjects;
-      this._isMultiSelection = true;
-    }
+    this._selectedObjects = allSelectedObjects;
+    this._isMultiSelection = allSelectedObjects.length > 1;
   }
 
   /**
    * Clears the multi-selection state and sets the `_isMultiSelection` flag to false.
    */
   private _handleSelectionCleared() {
-    if (this._selectedObjects.length > 1 && this._isMultiSelection) {
-      this._selectedObjects = [];
-      this._isMultiSelection = false;
-    }
+    this._selectedObjects = [];
+    this._isMultiSelection = false;
   }
 
   /**
@@ -131,7 +126,7 @@ export class CanvasWithHistory extends Canvas {
   /**
    * Handles object removal events.
    *
-   * @param options - The event object containing details about the removed object.
+   * @param options - The options object containing details about the removed object.
    */
   private _handleObjectRemoved(options: { target: FabricObject }) {
     /*
@@ -246,7 +241,7 @@ export class CanvasWithHistory extends Canvas {
    * Checks for whether or not an action can be redone.
    */
   canRedo() {
-    return this._historyRedo.length >= 1;
+    return this._historyRedo.length > 0;
   }
 
   /**
@@ -277,7 +272,7 @@ export class CanvasWithHistory extends Canvas {
   }
 
   /**
-   * Debug method to log relevant events to the console. Always remember to remove before pushing!
+   * Debug method to log relevant events to the console. Always remember to remove before pushing once you're done debugging locally!
    */
   private _historyDebug() {
     const EVENTS = [

--- a/tests/e2e/active-selection.test.ts
+++ b/tests/e2e/active-selection.test.ts
@@ -49,7 +49,9 @@ describe("ActiveSelection events", () => {
         (options: { target: FabricObject }) => {
           const targetType = options?.target?.type || "unknown";
           events.push(`${eventName} (${targetType})`);
-          console.log(`EVENT: ${eventName} (target: ${targetType})`);
+
+          // only uncomment if you want to see all events in real-time, make sure to comment it again before pushing (can be very verbose)
+          // console.log(`EVENT: ${eventName} (target: ${targetType})`);
         }
       );
     });
@@ -151,7 +153,7 @@ describe("ActiveSelection events", () => {
     console.log(`object:modified fired ${modifiedEvents.length} times`);
     console.log(`Modified event targets: ${modifiedEvents.join(", ")}`);
 
-    expect(true).toBe(true);
+    expect(movingEvents.length).toBeGreaterThan(0);
   });
 
   test("explore: what events fire when deleting an ActiveSelection", async () => {


### PR DESCRIPTION
## Description

Extends history management to properly handle multi-selected objects, ensuring batch operations create single history entries instead of one per object.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Changes Made

<!-- List the specific changes made in this PR -->

- Add `clearCanvas()` method for history-tracked canvas clearing (avoids conflicts with Fabric's internal `clear()` calls)
- Handle `selection:created` and `selection:updated` events to track multi-selection state
- Batch multi-object deletions into single history entry with undo/redo support
- Add E2E tests for ActiveSelection deletion, undo, and redo workflows
- Add integration test for `clearCanvas()` undo/redo

## Testing

<!-- Describe the testing you've done -->

- [x] Tests pass locally with `pnpm test`
- [x] Type checking passes with `pnpm check`
- [x] Build succeeds with `pnpm build`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation (if applicable)
