### PR TITLE
feat: add setEraserBrush method for eraser history tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ await canvas.undo();
 await canvas.redo();
 ```
 
+### Using with `@erase2d/fabric`
+
+To enable history tracking for erasing operations, use the `setEraserBrush` method with an `EraserBrush` from [`@erase2d/fabric`](https://github.com/erase2d/fabric). This ensures that erasing actions trigger the `erasing:end` event required for history tracking.
+
+```typescript
+import { CanvasWithHistory } from "@anth0nycodes/fabric-history";
+import { EraserBrush } from "@erase2d/fabric";
+
+const canvas = new CanvasWithHistory("my-canvas", {
+  width: 800,
+  height: 600,
+});
+
+// Create and set the eraser brush
+const eraser = new EraserBrush(canvas);
+eraser.width = 20;
+canvas.setEraserBrush(eraser);
+
+// Enable drawing mode to use the eraser
+canvas.isDrawingMode = true;
+```
+
 ## API
 
 ### `CanvasWithHistory`
@@ -67,15 +89,16 @@ Extends fabric.js `Canvas` class with history management capabilities.
 
 #### Methods
 
-| Method           | Returns         | Description                                                                                           |
-| ---------------- | --------------- | ----------------------------------------------------------------------------------------------------- |
-| `undo()`         | `Promise<void>` | Undo the most recent action                                                                           |
-| `redo()`         | `Promise<void>` | Redo the most recently undone action                                                                  |
-| `canUndo()`      | `boolean`       | Check if an undo action is available                                                                  |
-| `canRedo()`      | `boolean`       | Check if a redo action is available                                                                   |
-| `clearHistory()` | `void`          | Clear the undo and redo history stacks                                                                |
-| `clearCanvas()`  | `void`          | Clear the canvas and save the cleared state to history (use this instead of the inherited `clear()`) |
-| `dispose()`      | `void`          | Clean up event listeners and dispose the canvas                                                       |
+| Method                   | Returns         | Description                                                                                          |
+| ------------------------ | --------------- | ---------------------------------------------------------------------------------------------------- |
+| `undo()`                 | `Promise<void>` | Undo the most recent action                                                                          |
+| `redo()`                 | `Promise<void>` | Redo the most recently undone action                                                                 |
+| `canUndo()`              | `boolean`       | Check if an undo action is available                                                                 |
+| `canRedo()`              | `boolean`       | Check if a redo action is available                                                                  |
+| `setEraserBrush(eraser)` | `void`          | Set an `EraserBrush` from `@erase2d/fabric` to enable history tracking for erasing operations        |
+| `clearHistory()`         | `void`          | Clear the undo and redo history stacks                                                               |
+| `clearCanvas()`          | `void`          | Clear the canvas and save the cleared state to history (use this instead of the inherited `clear()`) |
+| `dispose()`              | `void`          | Clean up event listeners and dispose the canvas                                                      |
 
 #### Tracked Events
 
@@ -92,12 +115,12 @@ History is automatically saved when these fabric.js events occur:
 
 `CanvasWithHistory` fires custom events that you can listen to for history state changes:
 
-| Event             | Payload                                          | Description                        |
-| ----------------- | ------------------------------------------------ | ---------------------------------- |
-| `history:append`  | `{ json: string, initial: boolean }`             | Fired when a state is saved        |
-| `history:undo`    | `{ lastUndoAction: string }`                     | Fired when an undo is performed    |
-| `history:redo`    | `{ lastRedoAction: string }`                     | Fired when a redo is performed     |
-| `history:cleared` | `{}`                                             | Fired when history stacks cleared  |
+| Event             | Payload                              | Description                       |
+| ----------------- | ------------------------------------ | --------------------------------- |
+| `history:append`  | `{ json: string, initial: boolean }` | Fired when a state is saved       |
+| `history:undo`    | `{ lastUndoAction: string }`         | Fired when an undo is performed   |
+| `history:redo`    | `{ lastRedoAction: string }`         | Fired when a redo is performed    |
+| `history:cleared` | `{}`                                 | Fired when history stacks cleared |
 
 **Example:**
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     }
   },
   "devDependencies": {
+    "@erase2d/fabric": "^1.2.1",
     "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
     "@vitest/browser-playwright": "^4.0.18",
     "@vitest/coverage-v8": "^4.0.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
         specifier: '>=6.0.0 <8.0.0'
         version: 7.2.0
     devDependencies:
+      '@erase2d/fabric':
+        specifier: ^1.2.1
+        version: 1.2.1(fabric@7.2.0)
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.7.0
         version: 4.7.1(prettier@3.8.1)
@@ -166,6 +169,11 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@erase2d/fabric@1.2.1':
+    resolution: {integrity: sha512-7VgjhCD5yHDMA8HbHf0cpU0T1q/MKMJQwPajuparLUQXb2tPbnwmczWXvojt0dQ66VS4Rs2caRNVucM9P9FfEA==}
+    peerDependencies:
+      fabric: '>=6.0.0'
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -1366,6 +1374,10 @@ snapshots:
     optional: true
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@erase2d/fabric@1.2.1(fabric@7.2.0)':
+    dependencies:
+      fabric: 7.2.0
 
   '@esbuild/aix-ppc64@0.27.2':
     optional: true

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -1,3 +1,4 @@
+import type { EraserBrush, ErasingEvent } from "@erase2d/fabric";
 import {
   Canvas,
   type CanvasEvents,
@@ -267,15 +268,6 @@ export class CanvasWithHistory extends Canvas {
   }
 
   /**
-   * Clears the history stacks for undo and redo.
-   */
-  clearHistory() {
-    this._historySaveInitialState();
-    this._historyRedo = [];
-    this.fire("history:cleared");
-  }
-
-  /**
    * Debug method to log relevant events to the console. Always remember to remove before pushing once you're done debugging locally!
    */
   private _historyDebug() {
@@ -317,6 +309,34 @@ export class CanvasWithHistory extends Canvas {
       "selection:updated": this._handleSelectionUpdated.bind(this),
       "selection:cleared": this._handleSelectionCleared.bind(this),
     });
+  }
+
+  /**
+   * Sets the provided `EraserBrush` instance as the canvas's eraser brush. This method is necessary to ensure that erasing actions are properly recorded in the history stack, as the default Fabric.js eraser brush does not trigger the relevant events for history tracking.
+   *
+   * @param eraser - The EraserBrush instance to set as the canvas's eraser brush.
+   */
+  setEraserBrush(eraser: EraserBrush) {
+    this.freeDrawingBrush = eraser;
+
+    eraser.on("end", (e: ErasingEvent<"end">) => {
+      const { targets: erasedTargets, path } = e.detail;
+      this.fire("erasing:end", {
+        path,
+        targets: erasedTargets,
+        subTargets: [],
+        drawables: {},
+      });
+    });
+  }
+
+  /**
+   * Clears the history stacks for undo and redo.
+   */
+  clearHistory() {
+    this._historySaveInitialState();
+    this._historyRedo = [];
+    this.fire("history:cleared");
   }
 
   /**

--- a/tests/e2e/path-erasing.test.ts
+++ b/tests/e2e/path-erasing.test.ts
@@ -1,0 +1,163 @@
+import { EraserBrush } from "@erase2d/fabric";
+import { PencilBrush, type CanvasEvents, type FabricObject } from "fabric";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { CanvasWithHistory } from "../../src/canvas.js";
+
+describe("Path creation and erasing events", () => {
+  let canvasEl: HTMLCanvasElement;
+  let canvas: CanvasWithHistory;
+  let events: string[];
+
+  beforeEach(() => {
+    canvasEl = document.createElement("canvas");
+    canvasEl.id = "test-canvas";
+    canvasEl.width = 800;
+    canvasEl.height = 600;
+    document.body.appendChild(canvasEl);
+
+    events = [];
+    canvas = new CanvasWithHistory(canvasEl, {
+      width: 800,
+      height: 600,
+    });
+
+    const eventsToTrack = [
+      "path:created",
+      "erasing:end",
+      "object:added",
+      "history:append",
+    ];
+
+    eventsToTrack.forEach((eventName) => {
+      canvas.on(
+        eventName as keyof CanvasEvents,
+        (options: { target: FabricObject }) => {
+          const targetType = options?.target?.type || "unknown";
+          events.push(`${eventName} (${targetType})`);
+        }
+      );
+    });
+  });
+
+  afterEach(() => {
+    canvas.dispose();
+    document.body.removeChild(canvasEl);
+  });
+
+  /** Helper to simulate drawing/erasing gesture on the canvas */
+  function simulateDrawingGesture(
+    upperCanvas: HTMLCanvasElement,
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    steps = 5
+  ) {
+    const rect = upperCanvas.getBoundingClientRect();
+    const actualStartX = rect.left + startX;
+    const actualStartY = rect.top + startY;
+    const actualEndX = rect.left + endX;
+    const actualEndY = rect.top + endY;
+
+    // Mouse down to start
+    upperCanvas.dispatchEvent(
+      new MouseEvent("mousedown", {
+        clientX: actualStartX,
+        clientY: actualStartY,
+        bubbles: true,
+      })
+    );
+
+    // Mouse move in steps
+    for (let i = 1; i <= steps; i++) {
+      const currentX = actualStartX + ((actualEndX - actualStartX) * i) / steps;
+      const currentY = actualStartY + ((actualEndY - actualStartY) * i) / steps;
+      upperCanvas.dispatchEvent(
+        new MouseEvent("mousemove", {
+          clientX: currentX,
+          clientY: currentY,
+          bubbles: true,
+        })
+      );
+    }
+
+    // Mouse up to finish
+    upperCanvas.dispatchEvent(
+      new MouseEvent("mouseup", {
+        clientX: actualEndX,
+        clientY: actualEndY,
+        bubbles: true,
+      })
+    );
+  }
+
+  test("path:created fires when drawing with PencilBrush", async () => {
+    // Set up PencilBrush for free drawing
+    canvas.freeDrawingBrush = new PencilBrush(canvas);
+    canvas.freeDrawingBrush.width = 5;
+    canvas.isDrawingMode = true;
+
+    // Get the upper canvas (Fabric handles pointer events here)
+    const wrapper = canvasEl.parentElement!;
+    const upperCanvas = wrapper.querySelector(
+      ".upper-canvas"
+    ) as HTMLCanvasElement;
+
+    // Simulate drawing a path
+    simulateDrawingGesture(upperCanvas, 100, 100, 200, 150);
+
+    // Verify path:created was fired
+    const pathCreatedEvents = events.filter((e) => e.includes("path:created"));
+    console.log("Events fired:", events);
+
+    expect(pathCreatedEvents.length).toBe(1);
+    expect(canvas.getObjects().length).toBe(1);
+    expect(canvas.getObjects()[0].type).toBe("path");
+  });
+
+  /**
+   * This test verifies erasing:end fires when using EraserBrush via setEraserBrush.
+   * Related to: https://github.com/anth0nycodes/fabric-history/issues/15
+   */
+  test("erasing:end fires when erasing a path", async () => {
+    // Get the upper canvas
+    const wrapper = canvasEl.parentElement!;
+    const upperCanvas = wrapper.querySelector(
+      ".upper-canvas"
+    ) as HTMLCanvasElement;
+
+    // Step 1: Draw a path first
+    canvas.freeDrawingBrush = new PencilBrush(canvas);
+    canvas.freeDrawingBrush.width = 10;
+    canvas.isDrawingMode = true;
+
+    simulateDrawingGesture(upperCanvas, 100, 100, 300, 100);
+
+    expect(canvas.getObjects().length).toBe(1);
+
+    // Ensure the path is erasable
+    const path = canvas.getObjects()[0];
+    path.set("erasable", true);
+    canvas.renderAll();
+
+    console.log("After drawing - Events:", events);
+    console.log("Path erasable:", path.get("erasable"));
+    events.length = 0; // Clear events
+
+    // Step 2: Switch to EraserBrush using setEraserBrush (bridges @erase2d/fabric events)
+    const eraser = new EraserBrush(canvas);
+    eraser.width = 20;
+    canvas.setEraserBrush(eraser);
+    canvas.isDrawingMode = true;
+
+    // Erase over the same area where the path was drawn
+    simulateDrawingGesture(upperCanvas, 100, 100, 300, 100);
+
+    console.log("After erasing - Events:", events);
+    console.log("Objects after erasing:", canvas.getObjects().length);
+
+    // Verify erasing:end was fired
+    const erasingEndEvents = events.filter((e) => e.includes("erasing:end"));
+    expect(erasingEndEvents.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

Added new `setEraserBrush` method to enable proper eraser history tracking. Also added additional e2e tests to test if `erasing:end` events are being fired.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Issues

Fixes #15

## Changes Made

<!-- List the specific changes made in this PR -->

- added new `setEraserBrush` method
- add e2e test

## Testing

<!-- Describe the testing you've done -->

- [x] Integration tests pass locally with `pnpm test:it`
- [x] E2E tests pass locally with `pnpm test:e2e`
- [x] Type checking passes with `pnpm check`
- [x] Build succeeds with `pnpm build`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation (if applicable)
